### PR TITLE
Handle tables with double quotes while generating INSERT statements

### DIFF
--- a/kanboard-sqlite2mysql.sh
+++ b/kanboard-sqlite2mysql.sh
@@ -149,7 +149,7 @@ sqlite_dump_table_data()
     
     echo -e ".mode insert ${table}\nselect * from ${table};" \
         | sqlite3 ${sqliteDbFile} \
-        | sed -e "s/INSERT INTO \([a-z_]*\)/INSERT INTO \1 (${columns})/"
+        | sed -e "s/INSERT INTO \([a-z_\"]*\)/INSERT INTO \1 (${columns})/"
 }
 
 # If verbose, displays version of the schema found in the SQLite file. Beware this version is different from MySQL schema versions


### PR DESCRIPTION
While dumping SQLite database with schema 120, for a reason I can't
explain the table 'groups' was quotted by sqlite3 in it's output.
The following command (from sqlite_dump_table_data() function) returned:

    echo -e '.mode insert groups\nselect * from groups;' |sqlite3 <db path>
    INSERT INTO "groups" VALUES(5,'','kanboard-admins');
    INSERT INTO "groups" VALUES(6,'','kanboard-managers');
    […]

And thus the sed regexp failed silently, resulting in lines looking like
this in the generated dump:

    INSERT INTO  ("id","external_id","name")"groups" VALUES(6,'','kanboard-managers');

It was the only table in this case.

This PR fixes the sed regexp.