### PR TITLE
Handle inconsistant syntax of sqlite3 .schema output

### DIFF
--- a/kanboard-sqlite2mysql.sh
+++ b/kanboard-sqlite2mysql.sh
@@ -123,7 +123,7 @@ sqlite_tables()
 {
     local sqliteDbFile=$1
     sqlite3 ${sqliteDbFile} .schema \
-        | sed -e '/[^C(]$/d' -e 's/CREATE TABLE \([a-z_]*\).*/\1/' -e '/^$/d'
+        | sed -e '/[^C(]$/d' -e '/^\s\+($/d' -e 's/CREATE TABLE \([a-z_]*\).*/\1/' -e '/^$/d'
 }
 
 # List column names of a SQLite table


### PR DESCRIPTION
While dumping SQLite database with schema version 120, the script
returned this error:

    Error: near ";": syntax error
    Error: near line 2: near ";": syntax error

It was caused by the .schema sqlite command for table 'tasks'. Instead
of being formated that way:

    CREATE TABLE <table> (

The 'tasks' table had its ( on its own line:

    CREATE TABLE IF NOT EXISTS "tasks"
            (

This PR add a sed regexp to handle this case.